### PR TITLE
 Corrected version identifier for da/bibelen1992

### DIFF
--- a/bibles/da/bibelen1992/info.js
+++ b/bibles/da/bibelen1992/info.js
@@ -1,6 +1,6 @@
 var info = {
 	"lang": "da",
-	"version": "bibelen",
+	"version": "bibelen1992",
 	"books": [
 		{
 			"name": "Første Mosebog",


### PR DESCRIPTION
@PrJared found this today:

Compare newly-added **bibelen1992**: 
https://github.com/Adventech/bible-tools/blob/deae751b16bb82103a838eb30c92b8d70a033cf6/bibles/da/bibelen1992/info.js#L3

... to existing **bibelen (1995)**:
https://github.com/Adventech/bible-tools/blob/deae751b16bb82103a838eb30c92b8d70a033cf6/bibles/da/bibelen/info.js#L3

This commit changes the former to **bibelen1992**:
https://github.com/Adventech/bible-tools/blob/57de4cbfc04bd84a2695e11370d10346a6349cd8/bibles/da/bibelen1992/info.js#L3