### PR TITLE
Update regexps.coffee

### DIFF
--- a/lib/Bible-Passage-Reference-Parser/src/kin/regexps.coffee
+++ b/lib/Bible-Passage-Reference-Parser/src/kin/regexps.coffee
@@ -114,7 +114,7 @@ bcv_parser::regexps.get_books = (include_apocrypha, case_sensitive) ->
 	,
 		osis: ["Deut"]
 		regexp: ///(^|#{bcv_parser::regexps.pre_book})(
-		(?:Gutegeka[\s\xa0]*Kwa[\s\xa0]*Kabiri|Deut)
+		(?:Gutegeka[\s\xa0]*kwa[\s\xa0]*Kabiri|Deut)
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["Josh"]
@@ -244,7 +244,7 @@ bcv_parser::regexps.get_books = (include_apocrypha, case_sensitive) ->
 	,
 		osis: ["Ezek"]
 		regexp: ///(^|#{bcv_parser::regexps.pre_book})(
-		(?:Ezek(?:eiyeli)?)
+		(?:Ezek(?:iyeli)?)
 			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi
 	,
 		osis: ["Dan"]


### PR DESCRIPTION
Hello,
I was unable to change the Acts at line 350-353
osis: ["Acts"]
		regexp: ///(^|#{bcv_parser::regexps.pre_book})(
		(?:Ibyakozwe[\s\xa0]*N[\s\xa0]*Intumwa|Acts)
			)(?:(?=[\d\s\xa0.:,;\x1e\x1f&\(\)\uff08\uff09\[\]/"'\*=~\-\u2013\u2014])|$)///gi

It needs to be able to parse "Ibyakozwe n'Intumwa "I tried adding ['’]
(?:Ibyakozwe[\s\xa0]*n['’]Intumwa|Acts) but it didn't work.